### PR TITLE
Datavzrd report

### DIFF
--- a/resources/error_rates/nanopore.yaml
+++ b/resources/error_rates/nanopore.yaml
@@ -1,8 +1,0 @@
-spurious_ins_rate: 2.8e-6
-spurious_del_rate: 5.1e-6
-spurious_insext_rate: 0.0
-spurious_delext_rate: 0.0
-spurious_hop_ref_rate: 0.01
-spurious_hop_seq_rate: 0.02
-spurious_hop_ref_ext_rate: 0.05
-spurious_hop_seq_ext_rate: 0.1

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -19,8 +19,7 @@ include: "rules/annotate.smk"
 include: "rules/filter.smk"
 include: "rules/table.smk"
 include: "rules/plot.smk"
-include: "rules/report.smk"
-
+include: "rules/datavzrd.smk"
 
 rule all:
     input:

--- a/workflow/envs/datavzrd.yaml
+++ b/workflow/envs/datavzrd.yaml
@@ -1,0 +1,4 @@
+channels:
+  - conda-forge
+dependencies:
+  - datavzrd =1.16

--- a/workflow/envs/rbt.yaml
+++ b/workflow/envs/rbt.yaml
@@ -2,5 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - rust-bio-tools =0.38.2
+  - rust-bio-tools =0.39.1
   - bcftools =1.14

--- a/workflow/envs/varlociraptor.post-deploy.sh
+++ b/workflow/envs/varlociraptor.post-deploy.sh
@@ -1,1 +1,0 @@
-cargo install --git https://github.com/varlociraptor/varlociraptor --branch hphmm2 --rev d2a98eff12bb79a5092ccf98d99cf68b236fec09 --locked

--- a/workflow/envs/varlociraptor.yaml
+++ b/workflow/envs/varlociraptor.yaml
@@ -1,17 +1,4 @@
 channels:
   - conda-forge
 dependencies:
-  - rust =1.58.1
-  - git =2.35.0
-  - compilers =1.3.0
-  - pkg-config =0.29.2
-  - make =4.3
-  - cmake =3.21.3
-  - gsl =2.7
-  - libcblas =3.9.0
-  - openssl =3.0.0
-  - zlib =1.2.11
-  - bzip2 =1.0.8
-  - xz =5.2.5
-  - clangdev =13.0.0
-  - blis =0.8.1
+  - varlociraptor =5.2.0

--- a/workflow/rules/call.smk
+++ b/workflow/rules/call.smk
@@ -70,6 +70,21 @@ rule varlociraptor_call:
         "--scenario {input.scenario} > {output} 2> {log}"
 
 
+rule varlociraptor_alignment_properties:
+    input:
+        ref=config["calling"]["reference"]["path"],
+        ref_idx=config["calling"]["reference"]["path"] + ".fai",
+        bam="results/calling/mapping/{sample}.bam",
+    output:
+        "results/calling/alignment-properties/{sample}.json",
+    log:
+        "logs/varlociraptor/estimate-alignment-properties/{sample}.log",
+    conda:
+        "../envs/varlociraptor.yaml"
+    shell:
+        "varlociraptor estimate alignment-properties {input.ref} --bam {input.bam} > {output} 2> {log}"
+
+
 rule varlociraptor_preprocess:
     input:
         ref=config["calling"]["reference"]["path"],
@@ -77,10 +92,11 @@ rule varlociraptor_preprocess:
         candidates=get_group_candidates,
         bam="results/calling/mapping/{sample}.bam",
         bai="results/calling/mapping/{sample}.bam.bai",
+        alignment_props="results/calling/alignment-properties/{sample}.json",
     output:
         "results/calling/calls/observations/{sample}.{scatteritem}.bcf",
     params:
-        model="resources/error_rates/nanopore.yaml",
+        mode=pairhmm_mode,
     log:
         "logs/varlociraptor/preprocess/{sample}.{scatteritem}.log",
     benchmark:
@@ -93,8 +109,9 @@ rule varlociraptor_preprocess:
     shell:
         "varlociraptor preprocess variants {input.ref} "
         "--candidates {input.candidates} "
-        "--model {params.model} "
         "--max-depth 200 "
+        "--alignment-properties {input.alignment_props} "
+        "--pairhmm-mode {params.mode} "
         "--bam {input.bam} --output {output} 2> {log}"
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -61,8 +61,8 @@ def get_all_input(wildcards):
     targets += expand(
         "results/calling/tables/{group}.sorted.annotated.csv", group=GROUPS
     )
-    targets += expand("results/calling/coverage_graphs/{group}/", group=GROUPS)
-    targets += expand("results/calling/report/tables/{group}", group=GROUPS)
+    targets += ["results/datavzrd-report/all.fdr-controlled"]
+    targets += expand("results/tmp/{group}.qc_plots.marker", group=GROUPS)
     return targets
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -66,6 +66,10 @@ def get_all_input(wildcards):
     return targets
 
 
+def pairhmm_mode(wildcards):
+    return "homopolymer" if samples.loc[wildcards.sample]["platform"] == "nanopore" else "exact"
+
+
 def get_group_candidates(wildcards):
     sample = wildcards.sample
     group = samples.loc[sample]["group"]

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -1,0 +1,52 @@
+rule render_datavzrd_config:
+    input:
+        template=workflow.source_path(
+            "../resources/datavzrd/circle-table-template.datavzrd.yaml"
+        ),
+        
+    output:
+        "resources/datavzrd/all.datavzrd.yaml",
+    params:
+        groups=lambda wc: GROUPS,
+        calls=lambda wc: [f"results/calling/tables/{group}.sorted.annotated.csv" for group in GROUPS],
+    log:
+        "logs/datavzrd_render/all.log",
+    template_engine:
+        "yte"
+
+
+rule copy_qc_plots_for_datavzrd:
+    input:
+        plots="results/calling/coverage_graphs/{group}",
+        report="results/datavzrd-report/all.fdr-controlled",
+    output:
+        marker="results/tmp/{group}.qc_plots.marker",
+    params:
+        output_dir=lambda wc: directory(f"results/datavzrd-report/all.fdr-controlled/circles-{wc.group}/qc_plots"),
+    shell:
+        """
+        mkdir -p {params.output_dir}
+        for f in `find {input.plots} -regex '.*/graph_[0-9]+_[0-9]+\.html'`; do ( cp "$f" {params.output_dir} ); done
+        touch {output.marker}
+        """
+
+
+rule datavzrd_circle_calls:
+    input:
+        config="resources/datavzrd/all.datavzrd.yaml",
+        calls=expand("results/calling/tables/{group}.sorted.annotated.csv", group=GROUPS),
+    output:
+        report(
+            directory("results/datavzrd-report/all.fdr-controlled"),
+            htmlindex="index.html",
+            #caption="../report/calls.rst",
+            category="Circle calls",
+            #labels=get_datavzrd_report_labels,
+            #subcategory=get_datavzrd_report_subcategory,
+        ),
+    conda:
+        "../envs/datavzrd.yaml"
+    log:
+        "logs/datavzrd_report/all.log",
+    shell:
+        "datavzrd {input.config} --output {output} &> {log}"


### PR DESCRIPTION
This PR replaces the old report with a datavzrd one, updates rust-bio-tools version used (vcf-split behaviour changed such that the order of appearance of BND records in the VCF file is unchanged when split) and also now uses an official varlociraptor release (instead of a specific git revision on a branch that has since been merged+deleted).