### PR TITLE
fix: copying annotation INFO fields from cyrcular to VCFs obtained from varlociraptor preprocess

### DIFF
--- a/workflow/envs/vcf_annotate.yaml
+++ b/workflow/envs/vcf_annotate.yaml
@@ -1,0 +1,8 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bcftools =1.15
+  - htslib =1.15
+  - vembrane =0.12
+  - ripgrep =13.0


### PR DESCRIPTION
Using `bcftools annotate` with VCF/BCF as input files does not work in conjunction with the `--columns ~ID` options. However, since we're dealing with breakends, we really need to match on IDs, not (only) on CHROM, POS, (REF, ALT).
So, what we have to do now is to use vembrane table to generate a tab delimited file, then bgzip that, use tabix to create an index for the file (making sure we're using the correct options) and then bcftools to actually do the annotation.