### PR TITLE
Expose gene annotation params

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,6 +8,9 @@ reference:
   build: GRCh38
   # Ensembl release
   release: 107
+  # flavor: ""  # optional, e.g. chr_patch_hapl_scaff, see Ensembl FTP.
+  # branch: ""  # optional
+
   # for available downloads, please browse either of these views:
   # * http://repeatmasker.org/genomicDatasets/RMGenomicDatasets.html
   # * http://repeatmasker.org/genomicDatasets/RMGenomicDatasetsAlt.html

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -97,8 +97,8 @@ rule download_gene_annotation:
         species=config["reference"]["species"],
         build=config["reference"]["build"],
         release=config["reference"]["release"],
-        flavor="",  # optional, e.g. chr_patch_hapl_scaff, see Ensembl FTP.
-        branch="",  # optional: specify branch
+        flavor=config["reference"]["flavor"],  # optional, e.g. chr_patch_hapl_scaff, see Ensembl FTP.
+        branch=config["reference"]["branch"],  # optional: specify branch
     log:
         "logs/download_gene_annotation.log",
     cache: "omit-software"  # save space and time with between workflow caching (see docs)

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -34,6 +34,12 @@ properties:
         type: integer
       build:
         type: string
+      flavor:
+        type: string
+      branch:
+        type: string
+      repeat_masker_download_link:
+        type: string
     required:
       - species
       - release
@@ -70,8 +76,11 @@ properties:
           type: number
           minimum: 0.0
           maximum: 1.0
-        local:
-          type: boolean
+        mode:
+          type: array
+          items:
+            type: string
+            enum: ["local-smart", "local-strict", "global-smart", "global-strict"]
         events:
           $ref: "#/definitions/evententry"
           description: "a map of <eventname: event> pairs"


### PR DESCRIPTION
Expose `flavor` and `branch` in the `config.yaml`. Also update the config schema accordingly (and fix the varlociraptor fdr mode schema entries)